### PR TITLE
Fix Intimacoes topbar position

### DIFF
--- a/src/pages/Intimacoes.tsx
+++ b/src/pages/Intimacoes.tsx
@@ -32,8 +32,8 @@ const Intimacoes: React.FC = () => {
 
   return (
 
-   <div>    
-    <div className="w-full h-screen flex flex-col space-y-8 items-center pt-5">
+   <div>
+    <div className="w-full h-screen flex flex-col space-y-8 items-center pt-5 mt-14">
         <div className="flex flex-col space-y-3 xl:w-[1200px]">
             <div className="font-bold text-black text-xl">Intimações</div>
             <div className='space-x-2.5'>

--- a/src/pages/Topbar.tsx
+++ b/src/pages/Topbar.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 
 const Topbar: React.FC = () => {
   const { role, logout } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const isIntimacoes = location.pathname.includes('intimacoes');
 
   const handleLogout = () => {
     logout();
@@ -12,7 +15,11 @@ const Topbar: React.FC = () => {
   };
 
   return (
-    <div className="bg-[#2C3E50] w-full h-14 flex justify-center">
+    <div
+      className={`${
+        isIntimacoes ? 'fixed top-0 left-0 w-full z-50' : ''
+      } bg-[#2C3E50] w-full h-14 flex justify-center`}
+    >
 			<div className="xl:w-[1200px] xl:h-full flex items-center justify-evenly whitespace-nowrap">
 				<span className="w-1/2 pb-2 text-xl font-bold text-white">Sistema Jurídico</span>
 


### PR DESCRIPTION
## Summary
- keep the topbar fixed on the Intimacoes page only
- offset Intimacoes content to avoid overlap

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c8848bc308328adf94ed3f14847f3