### PR TITLE
Adjust logout shrink and start JSON server via dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "sistema-juridico-frontend",
   "version": "1.0.0",
   "private": true,
-  "scripts": {    
-    "dev": "vite",
+  "scripts": {
+    "dev": "concurrently \"vite\" \"json-server --watch ./src/data/db.json --port 3000\"",
     "build": "vite build",
     "preview": "vite preview"
   },
@@ -32,6 +32,8 @@
     "postcss": "^8.5.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "concurrently": "^8.0.1",
+    "json-server": "^0.17.3"
   }
 }

--- a/src/pages/Topbar.tsx
+++ b/src/pages/Topbar.tsx
@@ -66,16 +66,36 @@ const Topbar: React.FC = () => {
           <li className="text-white pr-4">{role === 'admin' && <Link to="/admin/produtividade">|<span className="pr-4" />Produtividade</Link>}</li>
           <li className="text-white pr-4">{role === 'admin' && <Link to="/settings">|<span className="pr-4" />Configurações</Link>}</li>
 				</ul>
-        <button onClick={handleLogout} className="logout-button">
+        <button
+          onClick={handleLogout}
+          className="logout-button transition-all duration-300"
+        >
           <span className="flex items-center">
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" className="lucide lucide-log-out-icon lucide-log-out">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="#fff"
+              stroke-width="2"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              className={`lucide lucide-log-out-icon lucide-log-out transition-all duration-300 ${
+                isIntimacoes && shrink ? 'w-3 h-3' : 'w-4 h-4'
+              }`}
+            >
               <path d="m16 17 5-5-5-5" />
               <path d="M21 12H9" />
               <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
             </svg>
-            <span className="text-white pl-2 pb-1">Logout</span>
+            <span
+              className={`text-white pl-2 pb-1 transition-all duration-300 ${
+                isIntimacoes && shrink ? 'text-[0.625rem]' : 'text-sm'
+              }`}
+            >
+              Logout
+            </span>
           </span>
-        </button>				
+        </button>
 			</div>
 		</div>
 


### PR DESCRIPTION
## Summary
- shrink logout icon/text when scrolling Intimações page
- update dev script to launch `json-server` with Vite
- add `concurrently` and `json-server` as dev dependencies

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run dev` *(fails: concurrently not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c90075d0083288c39943bff3eb15e